### PR TITLE
Add priority information into rendered task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### ✨ Features
+
+- Each rendered task now contains information about the task's priority. You can use this information to style each priority differently. These classes are `todoist-p1`, `todoist-p2`, `todoist-p3`, and `todoist-p4`. For example: 
+    ```css
+    .todoist-p1 input[type=checkbox] {
+        /* This matches against the input element rendered for a priority 1 task. */
+    }
+    ``` 
+
+## [1.0.0] - 2020-08-29
+
+This was the initial release of the Obsidian x Todoist plugin. It contained the basic functionality for:
+
+- materializing tasks in an Obsidian note
+- allowing you to check tasks off from an Obsidian note

--- a/src/TodoistQuery.svelte
+++ b/src/TodoistQuery.svelte
@@ -45,6 +45,21 @@
     tasks = newTodos;
     fetching = false;
   }
+
+  // For some reason, the Todoist API returns priority in reverse order from
+  // the p1/p2/p3/p4 fluent entry notation.
+  function getPriorityClass(priority) {
+    switch (priority) {
+      case 1:
+        return "todoist-p4";
+      case 2:
+        return "todoist-p3";
+      case 3:
+        return "todoist-p2";
+      case 4:
+        return "todoist-p1";
+    }
+  }
 </script>
 
 <h4 class="todoist-query-title">{ query.name }</h4> 
@@ -66,7 +81,7 @@
 <br/>
 <ul>
 {#each todos as todo}
-<li class="task-list-item">
+<li class="task-list-item {getPriorityClass(todo.priority)}">
   <input 
     data-line="1" 
     class="task-list-item-checkbox"


### PR DESCRIPTION
These are introduced as classes on the task elements, allowing you to render them however you like. 

This PR also introduces a CHANGELOG based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). 