### PR TITLE
Use Todoist ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     .todoist-p1 input[type=checkbox] {
         /* This matches against the input element rendered for a priority 1 task. */
     }
-    ``` 
+    ```
+
+### 🔃 Changes
+
+- The rendered task list now uses the ordering as defined by the Todoist API.
 
 ## [1.0.0] - 2020-08-29
 

--- a/src/TodoistQuery.svelte
+++ b/src/TodoistQuery.svelte
@@ -42,6 +42,7 @@
 
     let newTodos = await res.json();
     newTodos.forEach(task => task.done = false);
+    newTodos.sort((first, second) => first.order - second.order);
     tasks = newTodos;
     fetching = false;
   }


### PR DESCRIPTION
The API returns tasks with an 'order' parameter, so we should use this (by default) when rendering the list. 