### PR TITLE
Add settings tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ✨ Features
 
-- Each rendered task now contains information about the task's priority. You can use this information to style each priority differently. These classes are `todoist-p1`, `todoist-p2`, `todoist-p3`, and `todoist-p4`. For example: 
+- Each rendered task's CSS now contains information about the task's priority. You can use this information to style each priority differently. These classes are `todoist-p1`, `todoist-p2`, `todoist-p3`, and `todoist-p4`. For example: 
     ```css
     .todoist-p1 input[type=checkbox] {
         /* This matches against the input element rendered for a priority 1 task. */
     }
     ```
-
-- When a task is removed or added, it now transitions with a smooth fading effect, rather than immediately being added/removed.
-- Each query can now auto-refresh if configured to do so. Note that the `autorefresh` field is in seconds.
+- When a task is removed or added, it now transitions with a smooth fading effect, rather than immediately being added/removed. This can be turned off in the settings.
+- Added support for auto-refreshing queries. This can be set at a global level within the settings tab or overridden for each individual query. For example:
     `````markdown
     ```json
     {
@@ -26,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     }
     ```
     `````
+- Added a setting tab in the Obsidian setting menu. There are three settings included in this release:
+    - "Task fade animation" - controls whether to use the fade animation
+    - "Auto-refresh" - controls whether all queries should auto-refresh
+    - "Auto-refresh interval" - controls the default interval for auto-refreshing queries
 
 ### 🔃 Changes
 

--- a/README.md
+++ b/README.md
@@ -25,11 +25,21 @@ _Tested with Obsidian 0.8.4 and Volcano 1.0.6, your results may vary!_
 
 ## Inputs
 
-| Name          | Required | Description                                                                                 | Type   | Default |
-| ------------- | :------: | ------------------------------------------------------------------------------------------- | ------ | ------- |
-| `name`        |    ✓     | The title for the materialized query.                                                       | string |         |
-| `filter`      |    ✓     | Any valid [Todoist filter](https://get.todoist.help/hc/en-us/articles/205248842-Filters)    | string |         |
-| `autorefresh` |          | The number of seconds between auto-refreshing. If omitted, the query will not auto-refresh. | number | null    |
+| Name          | Required | Description                                                                                           | Type   | Default |
+| ------------- | :------: | ----------------------------------------------------------------------------------------------------- | ------ | ------- |
+| `name`        |    ✓     | The title for the materialized query.                                                                 | string |         |
+| `filter`      |    ✓     | Any valid [Todoist filter](https://get.todoist.help/hc/en-us/articles/205248842-Filters)              | string |         |
+| `autorefresh` |          | The number of seconds between auto-refreshing. If omitted, the query use the default global settings. | number | null    |
+
+## Settings
+
+This plugin adds a setting tab to the Obsidian settings menu. This controls global settings for this plugin.
+
+| Name                  | What does it control?                                                                       | Default |
+| --------------------- | ------------------------------------------------------------------------------------------- | ------- |
+| Task fade animation   | Whether tasks should fade in and out when added or removed.                                 | true    |
+| Auto-refresh          | Whether queries should auto-refresh at a set interval.                                      | false   |
+| Auto-refresh interval | The interval (in seconds) that queries should auto-refresh by default. Integer numbers only | 60      |
 
 ## CSS
 

--- a/src/TodoistQuery.svelte
+++ b/src/TodoistQuery.svelte
@@ -69,19 +69,27 @@
   }
 
   async function fetchTodos() {
-    fetching = true;
-    const url = new URL(`https://api.todoist.com/rest/v1/tasks?filter=${encodeURIComponent(query.filter)}`);
-    const res = await fetch(url, {
-      headers: new Headers({
-        'Authorization': `Bearer ${token}`
-      }),
-    });
+    if (fetching) {
+      return;
+    }
+    
+    try {
+      fetching = true;
+      const url = new URL(`https://api.todoist.com/rest/v1/tasks?filter=${encodeURIComponent(query.filter)}`);
+      const res = await fetch(url, {
+        headers: new Headers({
+          'Authorization': `Bearer ${token}`
+        }),
+      });
 
-    let newTodos = await res.json();
-    newTodos.forEach(task => task.done = false);
-    newTodos.sort((first, second) => first.order - second.order);
-    tasks = newTodos;
-    fetching = false;
+      let newTodos = await res.json();
+      newTodos.forEach(task => task.done = false);
+      newTodos.sort((first, second) => first.order - second.order);
+      tasks = newTodos;
+    }
+    finally {
+      fetching = false;
+    }
   }
 
   // For some reason, the Todoist API returns priority in reverse order from

--- a/src/TodoistQuery.svelte
+++ b/src/TodoistQuery.svelte
@@ -37,8 +37,6 @@
   $: todos = tasks.filter(task => !tasksPendingClose.includes(task.id));
 
   onMount(async () => {
-
-    }
     await fetchTodos();
   });
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,11 @@ module.exports = ({ SettingTab }) => {
 
     display() {
       this.containerEl.empty();
+      this.fadeAnimationSettings();
+      this.autoRefreshSettings();
+    }
 
+    fadeAnimationSettings() {
       const fadeToggle = this.addToggleSetting(
         "Task fade animation", 
         "Whether tasks should fade in and out when added or removed.");
@@ -18,13 +22,15 @@ module.exports = ({ SettingTab }) => {
       fadeToggle.onChange(() => {
         this.plugin.writeOptions(old => old.fadeToggle = fadeToggle.getValue());
       });
+    }
 
+    autoRefreshSettings() {
       const autoRefreshToggle = this.addToggleSetting(
         "Auto-refresh", 
         "Whether queries should auto-refresh at a set interval.");
-      autoRefreshToggle.setValue(this.plugin.options.autoRefresh);
+      autoRefreshToggle.setValue(this.plugin.options.autoRefreshToggle);
       autoRefreshToggle.onChange(() => {
-        this.plugin.writeOptions(old => old.autoRefreshSetting = autoRefreshToggle.getValue());
+        this.plugin.writeOptions(old => old.autoRefreshToggle = autoRefreshToggle.getValue());
       });
 
       const autoRefreshInterval = this.addTextSetting(
@@ -33,6 +39,11 @@ module.exports = ({ SettingTab }) => {
       autoRefreshInterval.setValue(`${this.plugin.options.autoRefreshInterval}`);
       autoRefreshInterval.onChange(() => {
         const newSetting = autoRefreshInterval.getValue().trim();
+
+        if (newSetting.length == 0) {
+          return;
+        }
+
         if (isPositiveInteger(newSetting)) {
           this.plugin.writeOptions(old => old.autoRefreshInterval = toInt(newSetting));
         } else {

--- a/src/index.js
+++ b/src/index.js
@@ -11,33 +11,30 @@ module.exports = ({ SettingTab }) => {
     display() {
       this.containerEl.empty();
 
-      const fadeToggle = this.addToggleSetting("Task fade animation", "Whether tasks should fade in and out when added or removed.");
-
+      const fadeToggle = this.addToggleSetting(
+        "Task fade animation", 
+        "Whether tasks should fade in and out when added or removed.");
       fadeToggle.setValue(this.plugin.options.fadeToggle);
-
       fadeToggle.onChange(() => {
-        this.plugin.options.fadeToggle = fadeToggle.getValue();
-        this.plugin.instance.saveData(this.plugin.options);
+        this.plugin.writeOptions(old => old.fadeToggle = fadeToggle.getValue());
       });
 
-      const autoRefreshToggle = this.addToggleSetting("Auto-refresh", "Whether queries should auto-refresh at a set interval.");
-
+      const autoRefreshToggle = this.addToggleSetting(
+        "Auto-refresh", 
+        "Whether queries should auto-refresh at a set interval.");
       autoRefreshToggle.setValue(this.plugin.options.autoRefresh);
-
       autoRefreshToggle.onChange(() => {
-        this.plugin.options.autoRefreshSetting = autoRefreshToggle.getValue();
-        this.plugin.instance.saveData(this.plugin.options);
+        this.plugin.writeOptions(old => old.autoRefreshSetting = autoRefreshToggle.getValue());
       });
 
-      const autoRefreshInterval = this.addTextSetting("Auto-refresh interval", "The interval (in seconds) that queries should auto-refresh by default. Integer numbers only");
-
+      const autoRefreshInterval = this.addTextSetting(
+        "Auto-refresh interval", 
+        "The interval (in seconds) that queries should auto-refresh by default. Integer numbers only");
       autoRefreshInterval.setValue(`${this.plugin.options.autoRefreshInterval}`);
-
       autoRefreshInterval.onChange(() => {
         const newSetting = autoRefreshInterval.getValue().trim();
         if (isPositiveInteger(newSetting)) {
-          this.plugin.options.autoRefreshInterval = toInt(newSetting);
-          this.plugin.instance.saveData(this.plugin.options);
+          this.plugin.writeOptions(old => old.autoRefreshInterval = toInt(newSetting));
         } else {
           autoRefreshInterval.setValue(`${this.plugin.options.autoRefreshInterval}`);
         }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,50 @@
 import Plugin from "./plugin.js";
+import { toInt, isPositiveInteger } from "./utils.js";
 
-module.exports = () => {
-  return new Plugin();
+module.exports = ({ SettingTab }) => {
+  class Settings extends SettingTab {
+    constructor(app, instance, plugin) {
+      super(app, instance);
+      this.plugin = plugin;
+    }
+
+    display() {
+      this.containerEl.empty();
+
+      const fadeToggle = this.addToggleSetting("Task fade animation", "Whether tasks should fade in and out when added or removed.");
+
+      fadeToggle.setValue(this.plugin.options.fadeToggle);
+
+      fadeToggle.onChange(() => {
+        this.plugin.options.fadeToggle = fadeToggle.getValue();
+        this.plugin.instance.saveData(this.plugin.options);
+      });
+
+      const autoRefreshToggle = this.addToggleSetting("Auto-refresh", "Whether queries should auto-refresh at a set interval.");
+
+      autoRefreshToggle.setValue(this.plugin.options.autoRefresh);
+
+      autoRefreshToggle.onChange(() => {
+        this.plugin.options.autoRefreshSetting = autoRefreshToggle.getValue();
+        this.plugin.instance.saveData(this.plugin.options);
+      });
+
+      const autoRefreshInterval = this.addTextSetting("Auto-refresh interval", "The interval (in seconds) that queries should auto-refresh by default. Integer numbers only");
+
+      autoRefreshInterval.setValue(`${this.plugin.options.autoRefreshInterval}`);
+
+      autoRefreshInterval.onChange(() => {
+        const newSetting = autoRefreshInterval.getValue().trim();
+        if (isPositiveInteger(newSetting)) {
+          this.plugin.options.autoRefreshInterval = toInt(newSetting);
+          this.plugin.instance.saveData(this.plugin.options);
+        } else {
+          autoRefreshInterval.setValue(`${this.plugin.options.autoRefreshInterval}`);
+        }
+      });
+    }
+  }
+
+
+  return new Plugin((app, instance, plugin) => new Settings(app, instance, plugin));
 };

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,0 +1,7 @@
+import { writable } from 'svelte/store';
+
+export const Settings = writable({
+  fadeToggle: true, 
+  autoRefreshToggle: false, 
+  autoRefreshInterval: 60,
+});

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,8 @@
+export function isPositiveInteger(str) {
+  const num = toInt(str);
+  return num != Infinity && String(num) === str && num > 0;
+}
+
+export function toInt(str) {
+  return Math.floor(Number(str));
+}


### PR DESCRIPTION
Added a settings tab to control global defaults for Todoist queries. This has three settings corresponding to features added in #5 and #6:

| Name                  | What does it control?                                                                       | Default |
| --------------------- | ------------------------------------------------------------------------------------------- | ------- |
| Task fade animation   | Whether tasks should fade in and out when added or removed.                                 | true    |
| Auto-refresh          | Whether queries should auto-refresh at a set interval.                                      | false   |
| Auto-refresh interval | The interval (in seconds) that queries should auto-refresh by default. Integer numbers only | 60      |