### PR TITLE
Add sorting options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         width: 17px;
     }
     ```
+- Added support for controlling the ordering of the rendered tasks. This can be done by either priority or date, or a combination of them (e.g. - sort by priority, then by date). To use this feature, amend your queries:
+    ``````markdown
+    ```json
+    {
+        "name": "My Tasks",
+        "filter": "today | overdue",
+        "autorefresh": 30,
+        "sorting": ["date", "priority"]
+    }
+    ```
+    ``````
 
 ### ⚙ Internal
 
@@ -44,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     ```json
     {
         "name": "My Tasks",
-        "filter" "today | overdue",
+        "filter": "today | overdue",
         "autorefresh": 30
     }
     ```

--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ _Tested with Obsidian 0.8.4 and Volcano 1.0.6, your results may vary!_
 
 ## Inputs
 
-| Name          | Required | Description                                                                                           | Type   | Default |
-| ------------- | :------: | ----------------------------------------------------------------------------------------------------- | ------ | ------- |
-| `name`        |    ✓     | The title for the materialized query.                                                                 | string |         |
-| `filter`      |    ✓     | Any valid [Todoist filter](https://get.todoist.help/hc/en-us/articles/205248842-Filters)\*            | string |         |
-| `autorefresh` |          | The number of seconds between auto-refreshing. If omitted, the query use the default global settings. | number | null    |
+| Name          | Required | Description                                                                                           | Type     | Default |
+|---------------|:--------:|-------------------------------------------------------------------------------------------------------|----------|---------|
+| `name`        |    ✓     | The title for the materialized query.                                                                 | string   |         |
+| `filter`      |    ✓     | Any valid [Todoist filter](https://get.todoist.help/hc/en-us/articles/205248842-Filters)\*            | string   |         |
+| `autorefresh` |          | The number of seconds between auto-refreshing. If omitted, the query use the default global settings. | number   | null    |
+| `sorting`     |          | Describes how to order the tasks in the query. Can be any of 'priority' or 'date', or multiple.       | string[] | []      |
 
 _\* Except for section filters like "/My Section"_
 
@@ -40,7 +41,7 @@ _\* Except for section filters like "/My Section"_
 This plugin adds a setting tab to the Obsidian settings menu. This controls global settings for this plugin.
 
 | Name                  | What does it control?                                                                       | Default |
-| --------------------- | ------------------------------------------------------------------------------------------- | ------- |
+|-----------------------|---------------------------------------------------------------------------------------------|---------|
 | Task fade animation   | Whether tasks should fade in and out when added or removed.                                 | true    |
 | Auto-refresh          | Whether queries should auto-refresh at a set interval.                                      | false   |
 | Auto-refresh interval | The interval (in seconds) that queries should auto-refresh by default. Integer numbers only | 60      |

--- a/src/TaskList.svelte
+++ b/src/TaskList.svelte
@@ -6,9 +6,10 @@
   export let tasks: Task[];
   export let settings: ISettings;
   export let api: TodoistApi;
+  export let sorting: string[];
 
   let tasksPendingClose: ID[] = [];
-  $: todos = tasks.filter((task) => !tasksPendingClose.includes(task.id));
+  $: todos = tasks.filter((task) => !tasksPendingClose.includes(task.id)).sort((first: Task, second: Task) => first.compareTo(second, sorting));
 
   async function onClickTask(task: Task) {
     tasksPendingClose.push(task.id);

--- a/src/TodoistQuery.svelte
+++ b/src/TodoistQuery.svelte
@@ -60,9 +60,7 @@
 
     try {
       fetching = true;
-      let newTodos = await api.getTasks(query.filter);
-      newTodos.sort((first: Task, second: Task) => first.order - second.order);
-      tasks = newTodos;
+      tasks = await api.getTasks(query.filter);
     } finally {
       fetching = false;
     }
@@ -90,4 +88,4 @@
   </svg>
 </button>
 <br />
-<TaskList {tasks} {settings} {api} />
+<TaskList {tasks} {settings} {api} sorting={query.sorting ?? []}/>

--- a/src/api.ts
+++ b/src/api.ts
@@ -106,6 +106,53 @@ export class Task {
     return this.datetime.add(1, 'day').isBefore();
   }
 
+  compareTo(other: Task, sorting_options: string[]): number {
+    console.log(sorting_options);
+    for (let sort of sorting_options) {
+      switch (sort) {
+        case "priority":
+          // Higher priority comes first.
+          const diff = other.priority - this.priority;
+          if (diff == 0) {
+            continue;
+          }
+
+          return diff;
+        case "date":
+          // We want to sort using the following criteria:
+          // 1. Any items without a datetime always are sorted after those with.
+          // 2. Any items on the same day without time always are sorted after those with.
+          if (this.datetime && !other.datetime) {
+            return -1;
+          } else if (!this.datetime && other.datetime) {
+            return 1;
+          } else if (!this.datetime && !other.datetime) {
+            continue;
+          }
+
+          // Now compare dates.
+          if (this.datetime.isAfter(other.datetime, 'day')) {
+            return 1;
+          } else if (this.datetime.isBefore(other.datetime, 'day')) {
+            return -1;
+          }
+
+          // We are the same day, lets look at time.
+          if (this.hasTime && !other.hasTime) {
+            return -1;
+          } else if (!this.hasTime && !other.hasTime) {
+            return 1;
+          } else if (!this.hasTime && !this.hasTime) {
+            continue;
+          }
+
+          return this.datetime.isBefore(other.datetime) ? -1 : 1;
+      }
+    }
+
+    return this.order - other.order;
+  }
+
   static buildTree(tasks: IApiTask[]): Task[] {
     const mapping = new Map<ID, Task>();
 

--- a/src/query.ts
+++ b/src/query.ts
@@ -2,4 +2,5 @@ export default interface IQuery {
   name: string;
   filter: string;
   autorefresh?: number;
+  sorting?: string[];
 }


### PR DESCRIPTION
This PR adds support for sorting options on a per-query basis. Currently you can sort by priority or date and define the ordering of these. I.e. - sort by priority first, then by date or vice versa. 

The base ordering is still the ordering as returned by the Todoist API.

Fixes #19 and fixes #14 