### PR TITLE
Stamp builds with version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### ✨ Features
+
+- The version of the plugin is now displayed in the settings tab along with a link to the changelog.
+
 ## [1.3.1] - 2020-09-18
 
 ### 🐛 Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "todoist-plugin",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -113,6 +113,15 @@
         "deepmerge": "^4.2.2",
         "is-module": "^1.0.0",
         "resolve": "^1.17.0"
+      }
+    },
+    "@rollup/plugin-replace": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.3.3.tgz",
+      "integrity": "sha512-XPmVXZ7IlaoWaJLkSCDaa0Y6uVo5XQYHhiMFzOd5qSv5rE+t/UJToPIOE56flKIxBFQI27ONsxb7dqHnwSsjKQ==",
+      "requires": {
+        "@rollup/pluginutils": "^3.0.8",
+        "magic-string": "^0.25.5"
       }
     },
     "@rollup/plugin-typescript": {
@@ -646,6 +655,11 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
+    },
+    "git-tag-version": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/git-tag-version/-/git-tag-version-1.3.1.tgz",
+      "integrity": "sha512-bhMl/aTCduq+Ll+Cw0sBz7zp8eIIZ6zv2mmYP2SiMdQoPtKSaVLGYDE9vcsDbbQt53zNnyi9CUbWOYJIzHrrFg=="
     },
     "glob": {
       "version": "7.1.6",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   "dependencies": {
     "@rollup/plugin-commonjs": "^15.0.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
+    "@rollup/plugin-replace": "^2.3.3",
+    "git-tag-version": "^1.3.1",
     "moment": "^2.27.0",
     "rollup": "^2.26.7",
     "rollup-plugin-svelte": "^6.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,25 +1,32 @@
-  
-import svelte from 'rollup-plugin-svelte';
-import resolve from '@rollup/plugin-node-resolve';
-import commonjs from '@rollup/plugin-commonjs';
-import typescript from '@rollup/plugin-typescript';
-import autoPreprocess from 'svelte-preprocess';
+import svelte from "rollup-plugin-svelte";
+import resolve from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
+import typescript from "@rollup/plugin-typescript";
+import autoPreprocess from "svelte-preprocess";
+import replace from "@rollup/plugin-replace";
+
+import gitVersion from "git-tag-version";
 
 export default {
-  input: 'src/index.js',
+  input: "src/index.js",
   output: {
-    format: 'iife',
-    file: 'dist/todoist.js'
+    format: "iife",
+    file: "dist/todoist.js",
   },
   plugins: [
+    replace({
+      __buildVersion__: gitVersion({ uniqueSnapshot: true }),
+    }),
     svelte({
-      preprocess: autoPreprocess()
+      preprocess: autoPreprocess(),
     }),
     typescript(),
     resolve({
       browser: true,
-      dedupe: ['svelte']
+      dedupe: ["svelte"],
     }),
-    commonjs()
-  ]
-}
+    commonjs(),
+  ],
+};
+
+function getBuildVersion() {}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -10,6 +10,8 @@ interface IInjection {
 }
 
 export default class TodoistPlugin<TBase extends Settings> {
+  public readonly version: string = "__buildVersion__";
+
   public id: string;
   public name: string;
   public description: string;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -59,6 +59,12 @@ export function SettingsTab<TBase extends Settings>(Base: TBase) {
       this.settingMgr = new SettingManager(this.containerEl);
       this.settingMgr.empty();
 
+      this.settingMgr.addStaticText({
+        name: `Current Version: ${this.plugin.version}`,
+        description: "",
+        configure: () => {},
+      });
+
       this.fadeAnimationSettings();
       this.autoRefreshSettings();
 
@@ -216,6 +222,10 @@ class SettingManager {
     const control = this.addSetting(config);
     const text = new TextSetting(control);
     config.configure(text);
+  }
+
+  public addStaticText(config: ISettingConfiguration<void>) {
+    const control = this.addSetting(config);
   }
 
   private addSetting<T>(config: ISettingConfiguration<T>): HTMLElement {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -59,11 +59,7 @@ export function SettingsTab<TBase extends Settings>(Base: TBase) {
       this.settingMgr = new SettingManager(this.containerEl);
       this.settingMgr.empty();
 
-      this.settingMgr.addStaticText({
-        name: `Current Version: ${this.plugin.version}`,
-        description: "",
-        configure: () => {},
-      });
+      this.pluginMetadata();
 
       this.fadeAnimationSettings();
       this.autoRefreshSettings();
@@ -71,6 +67,28 @@ export function SettingsTab<TBase extends Settings>(Base: TBase) {
       this.dateSettings();
       this.projectSettings();
       this.labelsSettings();
+    }
+
+    pluginMetadata() {
+      const desc = document.createElement("div") as HTMLDivElement;
+
+      const span = document.createElement("span") as HTMLSpanElement;
+      span.innerText = "Read the ";
+
+      const changelogLink = document.createElement("a") as HTMLAnchorElement;
+      changelogLink.href =
+        "https://github.com/jamiebrynes7/obsidian-todoist-plugin/releases";
+      changelogLink.innerText = "changelog!";
+
+      span.appendChild(changelogLink);
+
+      desc.appendChild(span);
+
+      this.settingMgr.addStaticText({
+        name: `Current Version: ${this.plugin.version}`,
+        description: desc,
+        configure: () => {},
+      });
     }
 
     fadeAnimationSettings() {
@@ -244,7 +262,13 @@ class SettingManager {
 
     const desc = document.createElement("div") as HTMLDivElement;
     desc.classList.add("setting-item-description");
-    desc.innerText = config.description;
+    if (typeof config.description == "string") {
+      const description = config.description as string;
+      desc.innerText = description;
+    } else {
+      const descriptionBlock = config.description as HTMLDivElement;
+      desc.appendChild(descriptionBlock);
+    }
     info.appendChild(desc);
 
     const control = document.createElement("div") as HTMLDivElement;
@@ -257,7 +281,7 @@ class SettingManager {
 
 interface ISettingConfiguration<TSettings> {
   name: string;
-  description: string;
+  description: string | HTMLDivElement;
   configure: (settings: TSettings) => void;
 }
 


### PR DESCRIPTION
This PR adds the ability to stamp each build with either a tag (or snapshot). This is then displayed in the settings tab with a link to the changelog.