### PR TITLE
Trigger close in modal when pressing enter

### DIFF
--- a/src/modals/createTask/CreateTaskModalContent.svelte
+++ b/src/modals/createTask/CreateTaskModalContent.svelte
@@ -68,6 +68,12 @@
       new Notice(`Failed to create task: '${result.unwrapErr().message}'`);
     }
   }
+
+  function handleKeydown(event: KeyboardEvent){
+    if(event.key === "Enter"){
+      triggerClose();
+    }
+  }
 </script>
 
 <style>
@@ -112,6 +118,8 @@
     line-height: 42px;
   }
 </style>
+
+<svelte:window on:keydown={handleKeydown} />
 
 <input bind:this={inputEl} type="text" bind:value placeholder="What to do?" />
 <div>


### PR DESCRIPTION
This PR allows users to add task by pressing the enter key in the CreateTaskModal, thus allowing for keyboard only entry of new Todoist tasks.

Is this something you would consider adding in the next version? Let me know if I should change anything, or if you're not accepting Pull Requests.