### PR TITLE
addes parantheses around the link

### DIFF
--- a/src/modals/createTask/createTaskModal.ts
+++ b/src/modals/createTask/createTaskModal.ts
@@ -53,9 +53,9 @@ export default class CreateTaskModal extends Modal {
     const vaultName = file.vault.getName();
     const filePath = file.path;
 
-    const link = `[${filePath}](obsidian://open?vault=${encodeURIComponent(
+    const link = `([${filePath}](obsidian://open?vault=${encodeURIComponent(
       vaultName
-    )}&file=${encodeURIComponent(filePath)})`;
+    )}&file=${encodeURIComponent(filePath)}))`;
 
     return [`${selection} ${link}`, selection.length];
   }


### PR DESCRIPTION
in the function 'Add Todoist task with the current page'
now there is parentheses around the link to indicate its is a link and not create visual cluster in the todo title