### PR TITLE
Feature filter filename replacements

### DIFF
--- a/src/query/injector.ts
+++ b/src/query/injector.ts
@@ -49,7 +49,7 @@ export class QueryInjector {
     let child: InjectedQuery;
 
     try {
-      const query = parseQuery(pendingQuery.source, this.app.workspace.getActiveFile().basename);
+      const query = parseQuery(pendingQuery);
 
       debug({
         msg: "Parsed query",

--- a/src/query/injector.ts
+++ b/src/query/injector.ts
@@ -49,7 +49,7 @@ export class QueryInjector {
     let child: InjectedQuery;
 
     try {
-      const query = parseQuery(pendingQuery.source);
+      const query = parseQuery(pendingQuery.source, this.app.workspace.getActiveFile().name);
 
       debug({
         msg: "Parsed query",

--- a/src/query/injector.ts
+++ b/src/query/injector.ts
@@ -49,7 +49,7 @@ export class QueryInjector {
     let child: InjectedQuery;
 
     try {
-      const query = parseQuery(pendingQuery.source, this.app.workspace.getActiveFile().name);
+      const query = parseQuery(pendingQuery.source, this.app.workspace.getActiveFile().basename);
 
       debug({
         msg: "Parsed query",

--- a/src/query/parser.ts
+++ b/src/query/parser.ts
@@ -59,7 +59,7 @@ function parseObject(query: any, fileName: string): Query {
   if (!query.hasOwnProperty("filter") || query.filter === null) {
     throw new ParsingError("Missing field 'filter' in query");
   }
-  query.filter = query.filter.replace(/{{filename}}/g, fileName.replace(/\s+/g, '').replace(/\.md$/i, ''));
+  query.filter = query.filter.replace(/{{filename}}/g, fileName.replace(/\s+/g, '*'));
   
   if (
     query.hasOwnProperty("autorefresh") &&

--- a/src/query/parser.ts
+++ b/src/query/parser.ts
@@ -19,7 +19,7 @@ export class ParsingError extends Error {
   }
 }
 
-export function parseQuery(raw: string): Query {
+export function parseQuery(raw: string, fileName: string): Query {
   let obj: any;
 
   try {
@@ -32,7 +32,7 @@ export function parseQuery(raw: string): Query {
     }
   }
 
-  return parseObject(obj);
+  return parseObject(obj, fileName);
 }
 
 function tryParseAsJson(raw: string): any {
@@ -51,7 +51,7 @@ function tryParseAsYaml(raw: string): any {
   }
 }
 
-function parseObject(query: any): Query {
+function parseObject(query: any, fileName: string): Query {
   if (!query.hasOwnProperty("name") || query.name === null) {
     throw new ParsingError("Missing field 'name' in query");
   }
@@ -59,7 +59,8 @@ function parseObject(query: any): Query {
   if (!query.hasOwnProperty("filter") || query.filter === null) {
     throw new ParsingError("Missing field 'filter' in query");
   }
-
+  query.filter = query.filter.replace(/{{filename}}/g, fileName.replace(/\s+/g, '').replace(/\.md$/i, ''));
+  
   if (
     query.hasOwnProperty("autorefresh") &&
     (isNaN(query.autorefresh) || (query.autorefresh as number) < 0)


### PR DESCRIPTION
I wanted the ability to pull in relevant tasks to the current note (use case: a project overview note, for example). Inline dataview and templater expressions do not appear to process before the Todoist query, so I added some functionality to expand {{filename}} within the query filter. Spaces replaced with asterisks for compatibility.

I am not super familiar with typescript and this may be considered hacky. Future improvements would be to include a toggle in settings for this, maybe adding a map of other possible expansions, etc.