### PR TITLE
feat: Fix sync button style, Fix intent level, Add button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the option to wrap page links in parenthesis when creating tasks with the command. You may find this useful if you primarily use Todoist on mobile where links are less obvious. Thanks to [@ThDag](https://github.com/ThDag) for the contribution!
 - You can now use the `{{filename}}` placeholder in the filter property. This will be replaced with the name of the file where the query is defined.
   - For example, if the full file path is `My Vault/Notes/How to Take Smart Notes.md` then the replaced file name will be `How to Take Smart Notes`.
+- Create "Add item" button - open same modal window of task creation. 
 
 ### 🔁 Changes
 
 - You can now toggle whether or not task descriptions are rendered for each task.
+- Change the style of the sync button to match the new Obsidian style of the "edit" button.
+- Fix intent level to match std markdown levels - to have consistent style.
 
 ## [1.11.1] - 2023-04-09
 

--- a/src/ui/TaskList.svelte
+++ b/src/ui/TaskList.svelte
@@ -41,7 +41,7 @@
 </script>
 
 {#if todos.length != 0}
-  <ul class="contains-task-list todoist-task-list">
+  <ul class="todoist-task-list">
     {#each todos as todo (todo.id)}
       <TaskRenderer
         {onClickTask}

--- a/src/ui/TaskRenderer.svelte
+++ b/src/ui/TaskRenderer.svelte
@@ -114,7 +114,7 @@
   transition:fade={{ duration: settings.fadeToggle ? 400 : 0 }}
   class="task-list-item {priorityClass} {dateTimeClass}"
 >
-  <div>
+  <div class="task-container">
     <input
       disabled={!isCompletable}
       data-line="1"

--- a/src/ui/TaskRenderer.svelte
+++ b/src/ui/TaskRenderer.svelte
@@ -114,7 +114,7 @@
   transition:fade={{ duration: settings.fadeToggle ? 400 : 0 }}
   class="task-list-item {priorityClass} {dateTimeClass}"
 >
-  <div class="task-container">
+  <div class="todoist-task-container">
     <input
       disabled={!isCompletable}
       data-line="1"

--- a/src/ui/TodoistQuery.svelte
+++ b/src/ui/TodoistQuery.svelte
@@ -6,6 +6,7 @@
   import type { Query } from "../query/query";
   import type { TodoistApi } from "../api/api";
   import type { Task, Project } from "../api/models";
+  import CreateTaskModal from "../modals/createTask/createTaskModal";
   import TaskList from "./TaskList.svelte";
   import GroupedTaskList from "./GroupedTaskList.svelte";
   import { Result } from "../result";
@@ -76,6 +77,14 @@
     }
   });
 
+  async function callTaskModal() {
+    new CreateTaskModal(
+      app,
+      api,
+      true
+    );
+  }
+
   async function fetchTodos() {
     if (fetching) {
       return;
@@ -97,17 +106,39 @@
 </script>
 
 <h4 class="todoist-query-title">{title}</h4>
-<button
-  class="todoist-refresh-button"
+<div
+  class="edit-block-button todoist-add-button"
+  on:click={async () => {
+    await callTaskModal();
+  }}
+  aria-label="Add item"
+>
+  <svg
+    class="svg-icon lucide-code-2"
+    width="20"
+    height="20"
+    viewBox="0 0 20 20"
+    fill="currentColor"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      fill-rule="evenodd"
+      d="M9 1v8H1v2h8v8h2v-8h8v-2h-8V1h-2z"
+      clip-rule="evenodd"
+    />
+  </svg>
+</div>
+<div
+  class={fetching ? "edit-block-button todoist-refresh-button todoist-refresh-disabled" : "edit-block-button todoist-refresh-button"}
   on:click={async () => {
     await fetchTodos();
   }}
-  disabled={fetching}
+  aria-label="Refresh list"
 >
   <svg
-    class={fetching ? "todoist-refresh-spin" : ""}
-    width="20px"
-    height="20px"
+    class={fetching ? "svg-icon lucide-code-2 todoist-refresh-spin" : "svg-icon lucide-code-2"}
+    width="20"
+    height="20"
     viewBox="0 0 20 20"
     fill="currentColor"
     xmlns="http://www.w3.org/2000/svg"
@@ -118,7 +149,7 @@
       clip-rule="evenodd"
     />
   </svg>
-</button>
+</div>
 <br />
 {#if fetchedOnce}
   {#if query.group}

--- a/src/ui/TodoistQuery.svelte
+++ b/src/ui/TodoistQuery.svelte
@@ -77,10 +77,11 @@
     }
   });
 
-  async function callTaskModal() {
+  function callTaskModal() {
     new CreateTaskModal(
       app,
       api,
+      settings,
       true
     );
   }
@@ -108,8 +109,8 @@
 <h4 class="todoist-query-title">{title}</h4>
 <div
   class="edit-block-button todoist-add-button"
-  on:click={async () => {
-    await callTaskModal();
+  on:click={() => {
+    callTaskModal();
   }}
   aria-label="Add item"
 >

--- a/styles.css
+++ b/styles.css
@@ -70,8 +70,14 @@
   margin-top: 20px;
 }
 
+.task-container {
+    text-indent:-30px;
+    padding-inline-start:32px;
+}
+
 .todoist-task-content {
   display: inline;
+  text-indent: 0px;
 }
 
 ul.todoist-task-list {
@@ -85,6 +91,7 @@ ul.todoist-task-list {
 
 .is-live-preview .block-language-todoist {
   padding-left: 15px;
+  padding-right: 10px;
 }
 
 .theme-dark {
@@ -137,6 +144,6 @@ ul.todoist-task-list {
 .todoist-task-description {
   font-size: 80%;
   color: var(--text-muted);
-  margin-left: 28px;
+  margin-left: 31px;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -70,7 +70,7 @@
   margin-top: 20px;
 }
 
-.task-container {
+.todoist-task-container {
     text-indent:-30px;
     padding-inline-start:32px;
 }

--- a/styles.css
+++ b/styles.css
@@ -71,7 +71,7 @@
 }
 
 .todoist-task-container {
-    text-indent: -28px;
+    text-indent: -38px;
     padding-inline-start: 30px;
 }
 
@@ -82,7 +82,7 @@
 
 ul.todoist-task-list {
   white-space: normal;
-  padding-inline-start: calc(var(--list-indent) - 15px);
+  padding-inline-start: calc(var(--list-indent) - 11px);
 }
 
 .markdown-reading-view .hide-in-reading-view {

--- a/styles.css
+++ b/styles.css
@@ -71,8 +71,8 @@
 }
 
 .todoist-task-container {
-    text-indent:-30px;
-    padding-inline-start:32px;
+    text-indent: -28px;
+    padding-inline-start: 30px;
 }
 
 .todoist-task-content {
@@ -144,6 +144,6 @@ ul.todoist-task-list {
 .todoist-task-description {
   font-size: 80%;
   color: var(--text-muted);
-  margin-left: 31px;
+  margin-left: 28px;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -3,15 +3,24 @@
   font-size: 1.25em;
 }
 
-.todoist-refresh-button {
-  display: inline;
+.todoist-add-button {
   margin-left: 8px;
-  margin-right: 8px;
-  float: right;
+  margin-right: 66px;
+}
+
+.todoist-refresh-button {
+  height: unset;
+  margin-left: 8px;
+  margin-right: 34px;
+}
+
+.todoist-refresh-disabled {
+  opacity: 0.5;
+  pointer-events: none;
 }
 
 .todoist-refresh-spin {
-  animation: spin 1s linear infinite;
+  animation: spin 1s linear infinite reverse;
 }
 
 @-webkit-keyframes spin {
@@ -67,6 +76,7 @@
 
 ul.todoist-task-list {
   white-space: normal;
+  padding-inline-start: calc(var(--list-indent) - 15px);
 }
 
 .markdown-reading-view .hide-in-reading-view {


### PR DESCRIPTION
Various style fixes for tasks list, mostly to match std markdown rendering. 

1. Change the style of the sync button:
   1.1. Move it to the left, as it was overlapping with the "Edit this block" button
   1.2. Change style to match "Edit this block"
   1.3. Add caption "Refresh list" on hover, similar to the "Edit this block"
   1.4. Fix icon rotation direction to match arrows =)
 
2. Create "Add item" button - open same modal window of task creation (style matches buttons above)

3. Fix intent level to match std markdown levels - to have consistent style. 
  (was higher than 2nd level, less than 3rd, now 2nd)

5. Fix intent level of the task title to match std markdown style - to have better readability, easy task identification.
  (was starting new line on the lave level as input box) 



| Old | New |
| --- | --- |
| <img width="500" alt="Screenshot 2023-12-13 at 20 53 40" src="https://github.com/jamiebrynes7/obsidian-todoist-plugin/assets/38007247/35c66fd7-981e-4df1-8261-e4d3174889a8"> | <img width="500" alt="Screenshot 2023-12-13 at 20 53 11" src="https://github.com/jamiebrynes7/obsidian-todoist-plugin/assets/38007247/d8150333-4728-41b9-99ca-90be0765b591"> |