### PR TITLE
Re-add default sorting order

### DIFF
--- a/src/ui/TodoistQuery.svelte
+++ b/src/ui/TodoistQuery.svelte
@@ -135,8 +135,8 @@
   {#if filteredTasks.length === 0}
     <NoTaskDisplay />
   {:else if query.group}
-    <GroupedTasks tasks={filteredTasks} sorting={query.sorting ?? []} />
+    <GroupedTasks tasks={filteredTasks} sorting={query.sorting ?? ["order"]} />
   {:else}
-    <TaskListRoot tasks={filteredTasks} sorting={query.sorting ?? []} />
+    <TaskListRoot tasks={filteredTasks} sorting={query.sorting ?? ["order"]} />
   {/if}
 {/if}


### PR DESCRIPTION
If the user does not provide a sorting order, use the default order as defined by Todoist

This at least means there is a stable sorting order & gives a sembalance of ordering.