### PR TITLE
Fix opening tasks in app on mobile devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed all icons to be part of the Lucide set to align with Obsidian.
 - The `title` part of the query is now optional.
 
+### 🐛 Bug Fixes
+
+- Opening tasks via the context menu should now work properly on mobile devices.
+
 ## [1.11.1] - 2023-04-09
 
 ### 🐛 Bug Fixes

--- a/src/contextMenu.ts
+++ b/src/contextMenu.ts
@@ -40,28 +40,20 @@ export function showTaskContext(
     .showAtPosition(position);
 }
 
-const openExternal: (url: string) => Promise<void> = async (url: string) => {
-  try {
-    await getElectronOpenExternal()(url);
-  } catch {
-    new Notice("Failed to open in external application.");
-  }
-};
+// A bit hacky, but in order to simulate clicking a link
+// we create a unparented DOM element, dispatch an event,
+// then remove the link. Using electron's openExternal doesn't
+// work on mobile unfortunately.
+function openExternal(url: string): void {
+  const link = document.createElement("a");
+  link.href = url;
 
-type OpenExternal = (url: string) => Promise<void>;
+  const clickEvent = new MouseEvent("click", {
+    bubbles: true,
+    cancelable: true,
+    view: window
+  });
 
-let electronOpenExternal: OpenExternal | undefined;
-
-function getElectronOpenExternal(): OpenExternal {
-  if (electronOpenExternal) {
-    return electronOpenExternal;
-  }
-
-  try {
-    electronOpenExternal = require("electron").shell.openExternal;
-  } catch (e) {
-    electronOpenExternal = (url) => Promise.resolve();
-  }
-
-  return electronOpenExternal;
+  link.dispatchEvent(clickEvent);
+  link.remove();
 }


### PR DESCRIPTION
Electron's `openExternal` is not available on mobile devices so this would fail. Instead we do a little workaround involving:

- creating a DOM link element
- simulating the user's click
- removing the element

Tested on iOS