### PR TITLE
chore: fix biome configuration on NixOS

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -13,6 +13,14 @@
 
   outputs = { self, nixpkgs, devenv, systems, ... }@inputs:
     let forEachSystem = nixpkgs.lib.genAttrs (import systems);
+    # HACK: We want to explicitly set the binary path for the biome binary to the musl variant.
+    # The default x86 build fails on NixOS installations, but the musl one works. The alternative is
+    # to install biome through Nix, but then we must synchronize the versions of the binaries which is icky.
+    enterShellBySystem = {
+      x86_64-linux = ''
+        export BIOME_BINARY=$(pwd)/plugin/node_modules/@biomejs/cli-linux-x64-musl/biome
+      '';
+    };
     in {
       devShells = forEachSystem (system:
         let pkgs = nixpkgs.legacyPackages.${system};
@@ -21,11 +29,19 @@
             inherit inputs pkgs;
             modules = [{
               packages = with pkgs; [
+                jq
                 nodejs
                 nodePackages.typescript-language-server
                 nodePackages.svelte-language-server
                 marksman
               ];
+              enterShell = enterShellBySystem.${system} or "";
+
+              scripts.patch-vscode-settings.exec = ''
+                # This script patches .vscode/settings.json to point to the musl variant of the biome binary.
+                # This is intended for use on NixOS based systems, where the x64 version of the binary doesn't work.
+                cat <<< $(jq '."biome.lspBin" = env.BIOME_BINARY' .vscode/settings.json) > .vscode/settings.json
+              '';
             }];
           };
         });


### PR DESCRIPTION
This commit fixes two problems. The first is that the default linux binary doesn't work on NixOS. So we set BIOME_BINARY explicitly to the musl variant if we are on a x64 linux system.

The other side of the coin is the biomejs-vscode extension. This has an argument for the binary which is great! But the loading of the environment and the initialisation of the biomejs extension is racey, so its unreliable. To fix this, I've added a 'patch-vscode-settings' script to the shell which will fixup the workspace settings so this will work