### PR TITLE
Tweak onboarding modal validation

### DIFF
--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -36,6 +36,10 @@ default Obsidian theme.
 - Rebuilt the task renderer from the ground up. This now resembles Todoist more closely and has improved the default styling.
 - Added support for translations in the plugin
 
+### 🔁 Changes
+
+- Tweaked the onboarding modal to hopefully be more reliable in validating the token and allowing you to save the token.
+
 ## v1.13.0 (2024-04-10)
 
 ### ✨ Features

--- a/plugin/src/token.ts
+++ b/plugin/src/token.ts
@@ -16,10 +16,7 @@ export namespace TokenValidation {
       return { kind: "error", message: i18n.emptyTokenError };
     }
 
-    const [isValid, _] = await Promise.all([
-      tester(token),
-      new Promise<void>((res) => setTimeout(() => res(), 1000)),
-    ]);
+    const isValid = await tester(token);
 
     if (!isValid) {
       return {

--- a/plugin/src/ui/onboardingModal/TokenInputForm.test.tsx
+++ b/plugin/src/ui/onboardingModal/TokenInputForm.test.tsx
@@ -18,20 +18,6 @@ describe("TokenInputForm", () => {
     expect(button).toHaveAttribute("disabled");
   });
 
-  it("should initially not show an error", () => {
-    render(
-      <TokenInputForm
-        onTokenSubmit={() => {}}
-        tester={async () => {
-          return true;
-        }}
-      />,
-    );
-
-    const textBox = screen.getByRole("textbox");
-    expect(textBox).not.toHaveAttribute("data-invalid");
-  });
-
   it("should show an error if input is empty after focus and unfocus", async () => {
     render(
       <TokenInputForm


### PR DESCRIPTION
It seems that using the focus change event was not reliable, or at
least, I suspect its what is behind some of the bug reports recently.
Rather than using focus changes, we use a debounced validation step
following token changes.