### PR TITLE
feat: add support for viewing completed tasks

### DIFF
--- a/docs/docs/query-blocks.md
+++ b/docs/docs/query-blocks.md
@@ -20,7 +20,11 @@ The query is defined as [YAML](https://yaml.org/) and there are a number of opti
 
 ### `filter`
 
-The filter option is **required** and should be a valid [Todoist filter](https://todoist.com/help/articles/introduction-to-filters-V98wIH). Note that this must be the content of the filter, you cannot refer to a filter that already exists in your Todoist account.
+The `filter` parameter is:
+- **Required** when viewing active tasks (`viewCompleted: false`)
+- **Optional** when viewing completed tasks (`viewCompleted: true`)
+
+Should be a valid [Todoist filter](https://todoist.com/help/articles/introduction-to-filters-V98wIH). Note that this must be the content of the filter, you cannot refer to a filter that already exists in your Todoist account.
 
 There are a few unsupported filters, these are tracked in [this GitHub issue](https://github.com/jamiebrynes7/obsidian-todoist-plugin/issues/34):
 
@@ -43,6 +47,8 @@ filter: "today | overdue"
 ### `autorefresh`
 
 The `autorefresh` option allows you to specify the number of seconds between automatic refreshes. This takes precedence over the plugin level setting. Omitting this option means the query will follow the plugin level settings.
+
+Note: When viewing completed tasks with `autorefresh` enabled, the refresh interval must be at least 9 seconds due to Todoist API rate limits.
 
 For example:
 
@@ -127,5 +133,48 @@ For example:
 ```todoist
 filter: "today | overdue"
 show: none
+```
+````
+
+### `viewCompleted`
+
+The `viewCompleted` option allows you to include completed tasks in your query results. By default, this is set to `false`. When set to `true`, completed tasks will be shown according to the specified `completedSince` and `completedUntil` parameters.
+
+For example:
+
+````
+```todoist
+viewCompleted: true
+completedLimit: 30
+```
+````
+
+### `completedLimit`
+
+The `completedLimit` option controls how many completed tasks to fetch. This value must not exceed 200 due to Todoist API limitations. If not specified, defaults to 30 tasks.
+
+For example:
+
+````
+```todoist
+viewCompleted: true
+completedLimit: 30
+```
+````
+
+### `completedSince` and `completedUntil`
+
+These options allow you to specify a date range for completed tasks. Both parameters accept ISO datetime strings.
+
+- `completedSince`: Only show tasks completed after this date (inclusive)
+- `completedUntil`: Only show tasks completed before this date (inclusive)
+
+For example:
+
+````
+```todoist
+viewCompleted: true
+completedSince: "2024-01-01T00:00:00"
+completedUntil: "2024-03-31T23:59:59"
 ```
 ````

--- a/plugin/src/api/domain/completedTask.ts
+++ b/plugin/src/api/domain/completedTask.ts
@@ -1,0 +1,30 @@
+import type { DueDate } from "@/api/domain/dueDate";
+import type { Priority } from "@/api/domain/task";
+
+export type CompletedTask = {
+  id: string;
+  task_id: string;
+  project_id: string;
+  section_id: string | null;
+  content: string;
+  completed_at: string;
+  note_count: number;
+  meta_data: string | null;
+  item_object: {
+    due?: DueDate | null;
+    description: string;
+    priority: Priority;
+    labels: string[];
+  };
+};
+
+export type CompletedTasksResponse = {
+  items: CompletedTask[];
+};
+
+export type GetCompletedTasksParams = {
+  project_id?: string;
+  limit?: number;
+  until?: Date;
+  since?: Date;
+};

--- a/plugin/src/data/task.ts
+++ b/plugin/src/data/task.ts
@@ -6,7 +6,7 @@ import type { Priority, TaskId } from "@/api/domain/task";
 
 export type Task = {
   id: TaskId;
-  createdAt: string;
+  createdAt?: string;
 
   content: string;
   description: string;
@@ -19,5 +19,5 @@ export type Task = {
   priority: Priority;
 
   due?: DueDate;
-  order: number;
+  order?: number;
 };

--- a/plugin/src/data/transformations/sorting.ts
+++ b/plugin/src/data/transformations/sorting.ts
@@ -33,7 +33,7 @@ function compareTask<T extends Task>(self: T, other: T, sorting: SortingVariant)
     case SortingVariant.DateDescending:
       return -compareTaskDate(self, other);
     case SortingVariant.Order:
-      return self.order - other.order;
+      return (self.order ?? 0) - (other.order ?? 0);
     case SortingVariant.DateAdded:
       return compareTaskDateAdded(self, other);
     case SortingVariant.DateAddedDescending:
@@ -89,8 +89,9 @@ function compareTaskDate<T extends Task>(self: T, other: T): number {
 }
 
 function compareTaskDateAdded<T extends Task>(self: T, other: T): number {
-  const selfDate = parseAbsoluteToLocal(self.createdAt);
-  const otherDate = parseAbsoluteToLocal(other.createdAt);
+  const now = new Date().toISOString();
+  const selfDate = parseAbsoluteToLocal(self.createdAt ?? now);
+  const otherDate = parseAbsoluteToLocal(other.createdAt ?? now);
 
   return selfDate.compare(otherDate) < 0 ? -1 : 1;
 }

--- a/plugin/src/query/parser.test.ts
+++ b/plugin/src/query/parser.test.ts
@@ -107,6 +107,35 @@ describe("parseQuery - rejections", () => {
         show: "nonee",
       },
     },
+    {
+      description: "completedLimit must be between 1 and 200",
+      input: {
+        viewCompleted: true,
+        completedLimit: 201,
+      },
+    },
+    {
+      description: "completedSince must be valid datetime",
+      input: {
+        viewCompleted: true,
+        completedSince: "invalid-date",
+      },
+    },
+    {
+      description: "completedUntil must be after completedSince",
+      input: {
+        viewCompleted: true,
+        completedSince: "2024-03-01T00:00:00",
+        completedUntil: "2024-02-01T00:00:00",
+      },
+    },
+    {
+      description: "autorefresh must be at least 9 seconds when viewing completed tasks",
+      input: {
+        viewCompleted: true,
+        autorefresh: 5,
+      },
+    },
   ];
 
   for (const tc of testcases) {
@@ -133,6 +162,10 @@ function makeQuery(opts?: Partial<Query>): Query {
         ShowMetadataVariant.Labels,
       ]),
     groupBy: opts?.groupBy ?? GroupVariant.None,
+    viewCompleted: opts?.viewCompleted ?? false,
+    completedLimit: opts?.completedLimit,
+    completedSince: opts?.completedSince,
+    completedUntil: opts?.completedUntil,
   };
 }
 
@@ -217,6 +250,34 @@ describe("parseQuery", () => {
       expectedOutput: makeQuery({
         filter: "bar",
         show: new Set(),
+      }),
+    },
+    {
+      description: "with viewCompleted",
+      input: {
+        filter: "bar",
+        viewCompleted: true,
+      },
+      expectedOutput: makeQuery({
+        filter: "bar",
+        viewCompleted: true,
+      }),
+    },
+    {
+      description: "with completed tasks parameters",
+      input: {
+        filter: "bar",
+        viewCompleted: true,
+        completedLimit: 100,
+        completedSince: "2024-01-01T00:00:00",
+        completedUntil: "2024-03-31T23:59:59",
+      },
+      expectedOutput: makeQuery({
+        filter: "bar",
+        viewCompleted: true,
+        completedLimit: 100,
+        completedSince: new Date("2024-01-01T00:00:00"),
+        completedUntil: new Date("2024-03-31T23:59:59"),
       }),
     },
   ];

--- a/plugin/src/query/query.ts
+++ b/plugin/src/query/query.ts
@@ -31,4 +31,8 @@ export type Query = {
   sorting: SortingVariant[];
   show: Set<ShowMetadataVariant>;
   groupBy: GroupVariant;
+  viewCompleted: boolean;
+  completedLimit?: number;
+  completedSince?: Date;
+  completedUntil?: Date;
 };

--- a/plugin/src/query/replacements.test.ts
+++ b/plugin/src/query/replacements.test.ts
@@ -61,6 +61,8 @@ describe("applyReplacements", () => {
           groupBy: GroupVariant.None,
           sorting: [],
           show: new Set(),
+          viewCompleted: false,
+          completedLimit: 1,
         };
 
         applyReplacements(query, new FakeContext(tc.filePath ?? ""));

--- a/plugin/src/ui/query/QueryRoot.tsx
+++ b/plugin/src/ui/query/QueryRoot.tsx
@@ -23,7 +23,7 @@ const useSubscription = (
   const [refreshedTimestamp, setRefreshedTimestamp] = useState<Date | undefined>(undefined);
 
   useEffect(() => {
-    const [unsub, refresh] = plugin.services.todoist.subscribe(query.filter, (results) => {
+    const [unsub, refresh] = plugin.services.todoist.subscribe(query, (results) => {
       callback(results);
       setRefreshedTimestamp(new Date());
     });
@@ -148,6 +148,14 @@ const QueryResponseHandler: React.FC<{
     return (
       <QueryContext.Provider value={query}>
         <Displays.Grouped tasks={tasks} />
+      </QueryContext.Provider>
+    );
+  }
+
+  if (query.viewCompleted) {
+    return (
+      <QueryContext.Provider value={query}>
+        <Displays.Completed tasks={tasks} />
       </QueryContext.Provider>
     );
   }

--- a/plugin/src/ui/query/displays/CompletedTaskDisplay.tsx
+++ b/plugin/src/ui/query/displays/CompletedTaskDisplay.tsx
@@ -1,0 +1,28 @@
+import type { Task } from "@/data/task";
+import { CompletedTask } from "@/ui/query/task/CompletedTask";
+import { AnimatePresence, motion } from "framer-motion";
+import type React from "react";
+
+type Props = {
+  tasks: Task[];
+};
+
+export const CompletedTaskDisplay: React.FC<Props> = ({ tasks }) => {
+  return (
+    <div className="todoist-tasks-list">
+      <AnimatePresence>
+        {tasks.map((task, index) => (
+          <motion.div
+            key={task.id}
+            className="todoist-task-container"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.4, delay: index * 0.1 }}
+          >
+            <CompletedTask task={task} />
+          </motion.div>
+        ))}
+      </AnimatePresence>
+    </div>
+  );
+};

--- a/plugin/src/ui/query/displays/index.ts
+++ b/plugin/src/ui/query/displays/index.ts
@@ -1,3 +1,4 @@
+import { CompletedTaskDisplay } from "@/ui/query/displays/CompletedTaskDisplay";
 import { EmptyDisplay } from "@/ui/query/displays/EmptyDisplay";
 import { ErrorDisplay } from "@/ui/query/displays/ErrorDisplay";
 import { GroupedDisplay } from "@/ui/query/displays/GroupedDisplay";
@@ -10,4 +11,5 @@ export const Displays = {
   List: ListDisplay,
   Grouped: GroupedDisplay,
   NotReady: NotReadyDisplay,
+  Completed: CompletedTaskDisplay,
 };

--- a/plugin/src/ui/query/task/CompletedTask.tsx
+++ b/plugin/src/ui/query/task/CompletedTask.tsx
@@ -1,0 +1,29 @@
+import type { Task } from "@/data/task";
+import { ShowMetadataVariant } from "@/query/query";
+import Markdown from "@/ui/components/markdown";
+import { QueryContext } from "@/ui/context";
+import type React from "react";
+
+type Props = {
+  task: Task;
+};
+
+export const CompletedTask: React.FC<Props> = ({ task }) => {
+  const query = QueryContext.use();
+
+  const shouldRenderDescription =
+    query.show.has(ShowMetadataVariant.Description) && task.description !== "";
+
+  return (
+    <div className="todoist-task completed">
+      <div className="todoist-task-content">
+        <Markdown content={task.content} />
+        {shouldRenderDescription && (
+          <div className="todoist-task-description">
+            <Markdown content={task.description} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
This PR adds basic support for viewing completed tasks. Users can now:

* View completed tasks with `viewCompleted: true` parameter
* Filter completed tasks by date range using `completedSince` and `completedUntil`
* Limit the number of completed tasks shown with `completedLimit`
* Auto-refresh completed task queries with a minimum interval of 9 seconds due to sync API rate limits