### PR TITLE
plugin createTaskModal: add project color to icons

### DIFF
--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - You can now provide `show: none` in your query to hide all task metadata (project, due date, labels, description).
 - Your tasks' durations will now be rendered with the due date.
 - You can now set a task duration when creating a new task.
+- Project icons in the task creation modal will now show that project's color.
 
 ### 🔁 Changes
 

--- a/plugin/src/ui/components/obsidian-icon/index.tsx
+++ b/plugin/src/ui/components/obsidian-icon/index.tsx
@@ -9,9 +9,9 @@ type Props = {
   size: "xs" | "s" | "m" | "l" | "xl";
   id: string;
   className?: string;
-};
+} & Omit<React.HTMLAttributes<HTMLDivElement>, "size" | "id" | "className">;
 
-export const ObsidianIcon: React.FC<Props> = ({ size, id, className }) => {
+export const ObsidianIcon: React.FC<Props> = ({ size, id, className, ...rest }) => {
   const div = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (div.current === null) {
@@ -21,5 +21,12 @@ export const ObsidianIcon: React.FC<Props> = ({ size, id, className }) => {
     setIcon(div.current, id);
   }, [id]);
 
-  return <div className={classNames("obsidian-icon", className)} data-icon-size={size} ref={div} />;
+  return (
+    <div
+      className={classNames("obsidian-icon", className)}
+      data-icon-size={size}
+      ref={div}
+      {...rest}
+    />
+  );
 };

--- a/plugin/src/ui/createTaskModal/ProjectSelector.tsx
+++ b/plugin/src/ui/createTaskModal/ProjectSelector.tsx
@@ -227,7 +227,12 @@ const ProjectLabel: React.FC<{ project: Project }> = ({ project }) => {
 
   return (
     <>
-      <ObsidianIcon size="s" id={projectIcon} />
+      <ObsidianIcon
+        size="s"
+        id={projectIcon}
+        className="todoist-project-icon"
+        data-project-color={project.color}
+      />
       <div>{project.name}</div>
     </>
   );

--- a/plugin/src/ui/createTaskModal/styles.scss
+++ b/plugin/src/ui/createTaskModal/styles.scss
@@ -1,3 +1,5 @@
+@import "../../styles/colors.scss";
+
 .modal-popover {
   overflow-y: auto;
 }
@@ -353,6 +355,20 @@ button.project-selector {
       display: none;
     }
   }
+}
+
+.todoist-project-icon {
+  @each $name, $color in $todoist-colors {
+    &[data-project-color="#{$name}"] {
+      --todoist-project-color: var(--todoist-#{$name});
+    }
+
+    &[data-label-color="#{$name}"] {
+      --todoist-label-color: var(--todoist-#{$name});
+    }
+  }
+
+  color: var(--todoist-project-color);
 }
 
 .task-time-menu {


### PR DESCRIPTION
We have this information available already, so we just need to plumb it
through to the CSS.