### PR TITLE
vite.config.mts: update css output name

### DIFF
--- a/plugin/vite.config.mts
+++ b/plugin/vite.config.mts
@@ -59,7 +59,7 @@ export default defineConfig({
       external: ["obsidian"],
       output: {
         assetFileNames: (assetInfo) => {
-          if (assetInfo.name === "style.css") {
+          if (assetInfo.name === "main.css") {
             return "styles.css";
           }
 


### PR DESCRIPTION
I missed this when updating deps I guess, but the default output is now main.css... so we need to transform that into styles.css otherwise Obsidian does not pick it up!