### PR TITLE
fix: parse datetimes properly in new API

### DIFF
--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v2.2.1 (2025-09-22)
+
+### 🐛 Bug Fixes
+
+- Fixed an issue where task with times would cause the plugin to fail to load tasks.
+
 ## v2.2.0 (2025-09-21)
 
 ### ✨ Features

--- a/docs/versioned_docs/version-2.2.0/changelog.md
+++ b/docs/versioned_docs/version-2.2.0/changelog.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v2.2.1 (2025-09-22)
+
+### 🐛 Bug Fixes
+
+- Fixed an issue where task with times would cause the plugin to fail to load tasks.
+
 ## v2.2.0 (2025-09-21)
 
 ### ✨ Features

--- a/plugin/src/api/domain/dueDate.ts
+++ b/plugin/src/api/domain/dueDate.ts
@@ -1,5 +1,4 @@
 export type DueDate = {
   isRecurring: boolean;
   date: string;
-  datetime?: string;
 };

--- a/plugin/src/data/dueDate.test.ts
+++ b/plugin/src/data/dueDate.test.ts
@@ -55,8 +55,7 @@ describe("parse", () => {
     {
       description: "should parse a due date with time",
       input: {
-        date: "2024-02-01",
-        datetime: "2024-02-01T12:00:00",
+        date: "2024-02-01T12:00:00",
         isRecurring: false,
       },
       expected: {
@@ -73,8 +72,7 @@ describe("parse", () => {
     {
       description: "should parse a due date with time and timezone",
       input: {
-        date: "2024-02-01",
-        datetime: "2024-02-01T12:00:00Z",
+        date: "2024-02-01T12:00:00Z",
         isRecurring: false,
       },
       expected: {
@@ -108,8 +106,7 @@ describe("parse", () => {
     {
       description: "should parse a due date for today with time",
       input: {
-        date: "2024-01-01",
-        datetime: "2024-01-01T12:00:00",
+        date: "2024-01-01T12:00:00",
         isRecurring: false,
       },
       expected: {
@@ -143,9 +140,8 @@ describe("parse", () => {
     {
       description: "should parse a due date for tomorrow with time",
       input: {
-        date: "2024-01-02",
+        date: "2024-01-02T12:00:00",
         isRecurring: false,
-        datetime: "2024-01-02T12:00:00",
       },
       expected: {
         start: {
@@ -178,9 +174,8 @@ describe("parse", () => {
     {
       description: "should parse a due date for yesterday with time",
       input: {
-        date: "2023-12-31",
+        date: "2023-12-31T12:00:00",
         isRecurring: false,
-        datetime: "2023-12-31T12:00:00",
       },
       expected: {
         start: {
@@ -213,9 +208,8 @@ describe("parse", () => {
     {
       description: "should parse a due date for next week with time",
       input: {
-        date: "2024-01-06",
+        date: "2024-01-06T12:00:00",
         isRecurring: false,
-        datetime: "2024-01-06T12:00:00",
       },
       expected: {
         start: {
@@ -248,9 +242,8 @@ describe("parse", () => {
     {
       description: "should parse a due date for last week with time",
       input: {
-        date: "2023-12-29",
+        date: "2023-12-29T12:00:00",
         isRecurring: false,
-        datetime: "2023-12-29T12:00:00",
       },
       expected: {
         start: {
@@ -283,9 +276,8 @@ describe("parse", () => {
     {
       description: "should parse a date not this year with time",
       input: {
-        date: "2025-01-01",
+        date: "2025-01-01T12:00:00",
         isRecurring: false,
-        datetime: "2025-01-01T12:00:00",
       },
       expected: {
         start: {
@@ -318,9 +310,8 @@ describe("parse", () => {
     {
       description: "should parse a date that's overdue with time",
       input: {
-        date: "2023-06-01",
+        date: "2023-06-01T12:00:00",
         isRecurring: false,
-        datetime: "2023-06-01T12:00:00",
       },
       expected: {
         start: {
@@ -358,8 +349,7 @@ describe("parse with duration", () => {
       description: "should parse a due date with 30 minutes duration",
       input: {
         due: {
-          date: "2024-02-01",
-          datetime: "2024-02-01T12:00:00",
+          date: "2024-02-01T12:00:00",
           isRecurring: false,
         },
         duration: {
@@ -388,8 +378,7 @@ describe("parse with duration", () => {
       description: "should parse a due date with 2 days duration",
       input: {
         due: {
-          date: "2024-02-01",
-          datetime: "2024-02-01T12:00:00",
+          date: "2024-02-01T12:00:00",
           isRecurring: false,
         },
         duration: {
@@ -418,8 +407,7 @@ describe("parse with duration", () => {
       description: "should parse a due date that crosses to next day with duration",
       input: {
         due: {
-          date: "2024-02-01",
-          datetime: "2024-02-01T23:00:00",
+          date: "2024-02-01T23:00:00",
           isRecurring: false,
         },
         duration: {

--- a/plugin/src/data/dueDate.ts
+++ b/plugin/src/data/dueDate.ts
@@ -28,14 +28,15 @@ export type DueDate = {
 
 const parseDueDate = (dueDate: ApiDueDate, duration?: ApiDuration): DueDate => {
   let start: ZonedDateTime | CalendarDate;
-  if (dueDate.datetime !== undefined) {
-    // If the datetime comes with a trailing Z, then the task has a fixed timezone. We repsect
+  const hasTime = dueDate.date.includes("T");
+  if (hasTime) {
+    // If the datetime comes with a trailing Z, then the task has a fixed timezone. We respect
     // this and convert it into their local timezone. Otherwise, it is a floating timezone and we
     // simply parse it as a local datetime.
-    if (dueDate.datetime.endsWith("Z")) {
-      start = parseAbsolute(dueDate.datetime, timezone());
+    if (dueDate.date.endsWith("Z")) {
+      start = parseAbsolute(dueDate.date, timezone());
     } else {
-      start = fromDate(parseDateTime(dueDate.datetime).toDate(timezone()), timezone());
+      start = fromDate(parseDateTime(dueDate.date).toDate(timezone()), timezone());
     }
   } else {
     start = parseDate(dueDate.date);

--- a/plugin/src/data/transformations/sorting.test.ts
+++ b/plugin/src/data/transformations/sorting.test.ts
@@ -141,15 +141,13 @@ describe("sortTasks", () => {
         makeTask("d", {
           due: {
             isRecurring: false,
-            date: "2020-03-15",
-            datetime: "2020-03-15T15:00:00",
+            date: "2020-03-15T15:00:00",
           },
         }),
         makeTask("e", {
           due: {
             isRecurring: false,
-            date: "2020-03-15",
-            datetime: "2020-03-15T13:00:00",
+            date: "2020-03-15T13:00:00",
           },
         }),
       ],
@@ -158,15 +156,13 @@ describe("sortTasks", () => {
         makeTask("e", {
           due: {
             isRecurring: false,
-            date: "2020-03-15",
-            datetime: "2020-03-15T13:00:00",
+            date: "2020-03-15T13:00:00",
           },
         }),
         makeTask("d", {
           due: {
             isRecurring: false,
-            date: "2020-03-15",
-            datetime: "2020-03-15T15:00:00",
+            date: "2020-03-15T15:00:00",
           },
         }),
         makeTask("c", {
@@ -190,15 +186,13 @@ describe("sortTasks", () => {
         makeTask("e", {
           due: {
             isRecurring: false,
-            date: "2020-03-15",
-            datetime: "2020-03-15T13:00:00",
+            date: "2020-03-15T13:00:00",
           },
         }),
         makeTask("d", {
           due: {
             isRecurring: false,
-            date: "2020-03-15",
-            datetime: "2020-03-15T15:00:00",
+            date: "2020-03-15T15:00:00",
           },
         }),
         makeTask("c", {
@@ -233,15 +227,13 @@ describe("sortTasks", () => {
         makeTask("d", {
           due: {
             isRecurring: false,
-            date: "2020-03-15",
-            datetime: "2020-03-15T15:00:00",
+            date: "2020-03-15T15:00:00",
           },
         }),
         makeTask("e", {
           due: {
             isRecurring: false,
-            date: "2020-03-15",
-            datetime: "2020-03-15T13:00:00",
+            date: "2020-03-15T13:00:00",
           },
         }),
       ],

--- a/plugin/src/ui/createTaskModal/DueDateSelector.tsx
+++ b/plugin/src/ui/createTaskModal/DueDateSelector.tsx
@@ -187,15 +187,18 @@ const getLabel = (selected: DueDate | undefined) => {
     return t().createTaskModal.dateSelector.emptyDate;
   }
 
+  let dateString: string;
+  if (selected.timeInfo !== undefined) {
+    dateString = toZoned(
+      toCalendarDateTime(selected.date, selected.timeInfo.time),
+      timezone(),
+    ).toAbsoluteString();
+  } else {
+    dateString = selected.date.toString();
+  }
+
   const apiDueDate: ApiDueDate = {
-    date: selected.date.toString(),
-    datetime:
-      selected.timeInfo !== undefined
-        ? toZoned(
-            toCalendarDateTime(selected.date, selected.timeInfo.time),
-            timezone(),
-          ).toAbsoluteString()
-        : undefined,
+    date: dateString,
     isRecurring: false,
   };
 

--- a/plugin/vite.config.mts
+++ b/plugin/vite.config.mts
@@ -30,6 +30,11 @@ function getBuildStamp(): string {
   return `v${version}-${commitSha}-${timestamp}`;
 }
 
+function getShouldMinify(): boolean {
+  const env = loadEnv("prod", process.cwd());
+  return env?.VITE_ENV !== "dev";
+}
+
 export default defineConfig({
   plugins: [
     react(),
@@ -50,6 +55,7 @@ export default defineConfig({
   build: {
     // We aren't building a website, so we build in library mode
     // and bundle the output using our index.ts as the entrypoint.
+    minify: getShouldMinify(),
     lib: {
       entry: resolve(__dirname, "src/index.ts"),
       fileName: "main",


### PR DESCRIPTION
Relates to https://github.com/jamiebrynes7/obsidian-todoist-plugin/issues/430