### PR TITLE
plugin: use tsgo for type checking

### DIFF
--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -31,6 +31,7 @@
         "@testing-library/react": "16.3.0",
         "@types/node": "24.0.13",
         "@types/react-dom": "19.1.0",
+        "@typescript/native-preview": "^7.0.0-dev.20251130.1",
         "@vitejs/plugin-react": "4.6.0",
         "jsdom": "^24.0.0",
         "sass": "^1.71.1",
@@ -3520,6 +3521,123 @@
       "dependencies": {
         "@types/estree": "*"
       }
+    },
+    "node_modules/@typescript/native-preview": {
+      "version": "7.0.0-dev.20251130.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20251130.1.tgz",
+      "integrity": "sha512-0DcbBJM5xMvbUWl5ZNprFno6ZlGmkI1RHN4hW1jJza7D5Um0kSs4CU0fx2Z4uNxhY7a37Y6px5LkM3WF6gePQg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsgo": "bin/tsgo.js"
+      },
+      "optionalDependencies": {
+        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20251130.1",
+        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20251130.1",
+        "@typescript/native-preview-linux-arm": "7.0.0-dev.20251130.1",
+        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20251130.1",
+        "@typescript/native-preview-linux-x64": "7.0.0-dev.20251130.1",
+        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20251130.1",
+        "@typescript/native-preview-win32-x64": "7.0.0-dev.20251130.1"
+      }
+    },
+    "node_modules/@typescript/native-preview-darwin-arm64": {
+      "version": "7.0.0-dev.20251130.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20251130.1.tgz",
+      "integrity": "sha512-j0h3dgtd/te0r6CKiJWxkb/hrtudWjEbTpuxF3Iki1E87oPtig0mNJyzTgzZFLLWaXM16Iuwb/6Y79j/dWwWmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@typescript/native-preview-darwin-x64": {
+      "version": "7.0.0-dev.20251130.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20251130.1.tgz",
+      "integrity": "sha512-ZjKkYNjzw8XJtai/R7eUIlRA1MK3xleNEHn+lrI5WJjZqzmOeKHc0xhbzW3E9aIDTd1/9cyt9AcPLvrx5FFvMw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@typescript/native-preview-linux-arm": {
+      "version": "7.0.0-dev.20251130.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20251130.1.tgz",
+      "integrity": "sha512-ovlaIVqiJqtuXaP4R/o+ljcFA3pIIMHJ1LN2bqEQYhJJR3nTbx/xvmGtXG2EC3xzrZCgEMY974izascjaziqEg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@typescript/native-preview-linux-arm64": {
+      "version": "7.0.0-dev.20251130.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20251130.1.tgz",
+      "integrity": "sha512-FLsbHH4ZqjdZ9t6zawbvt0zx/4YO+XB3+eGBkorTY6uhK66UKkXn4ar9k7ovLjRf1C6Ozjb6qvptf0k9mEJl0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@typescript/native-preview-linux-x64": {
+      "version": "7.0.0-dev.20251130.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20251130.1.tgz",
+      "integrity": "sha512-Z7qOyRxiyQUPaLPb6VA4FtXLkIj/AOSIgaP1zguaIYXJAkfMkQbhMaViLwFziMIxlH3ysr6jbZsBmsdYhVa9cQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@typescript/native-preview-win32-arm64": {
+      "version": "7.0.0-dev.20251130.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20251130.1.tgz",
+      "integrity": "sha512-a3xBzkixBqg3a2KnYZLPvGlPEbxNXFdfFimiYXx4CJVeiXqJX5U9zhZ2uAxh3oMMW6pDzQmn87AfM4F3FyxDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@typescript/native-preview-win32-x64": {
+      "version": "7.0.0-dev.20251130.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20251130.1.tgz",
+      "integrity": "sha512-1rJCAv76ScP7inMJPWTN28BuDe55po3BcjQR0/j07hViJPVMn4bI+VlgLV0oZpYOuaM9Uk0ex0e14mr0fwcgQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.6.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -3,7 +3,7 @@
   "version": "2.2.1",
   "description": "A Todoist plugin for Obsidian",
   "scripts": {
-    "check": "tsc --noEmit",
+    "check": "tsgo --noEmit",
     "dev": "npm run check && VITE_ENV=dev vite build",
     "build": "vite build",
     "test": "vitest",
@@ -36,6 +36,7 @@
     "@testing-library/react": "16.3.0",
     "@types/node": "24.0.13",
     "@types/react-dom": "19.1.0",
+    "@typescript/native-preview": "^7.0.0-dev.20251130.1",
     "@vitejs/plugin-react": "4.6.0",
     "jsdom": "^24.0.0",
     "sass": "^1.71.1",


### PR DESCRIPTION
This is basically at feature parity except for crazy edge cases. Use this for npm run check instead of tsc.