### PR TITLE
plugin: fix Todoist API sync endpoint and query URL encoding

### DIFF
--- a/plugin/src/api/index.test.ts
+++ b/plugin/src/api/index.test.ts
@@ -75,6 +75,22 @@ describe("TodoistApiClient", () => {
       expect(pathname).toBe("/api/v1/tasks/filter");
       expect(params.get("query")).toBe("today");
     });
+
+    it("encodes filter with spaces using percent encoding", async () => {
+      const fetcher = makeFetcher();
+      fetcher.fetch.mockResolvedValueOnce(makePaginatedResponse([makeTask()]));
+
+      const client = new TodoistApiClient("test-token", fetcher);
+      await client.getTasks("(today | overdue) & assigned to: me");
+
+      const call = fetcher.fetch.mock.calls[0][0];
+      // Verify spaces are encoded as %20, not +
+      expect(call.url).toContain("%20");
+      expect(call.url).not.toContain("+");
+      // Verify the query param value is correct when decoded
+      const { params } = parseUrl(call.url);
+      expect(params.get("query")).toBe("(today | overdue) & assigned to: me");
+    });
   });
 
   describe("pagination", () => {
@@ -223,7 +239,7 @@ describe("TodoistApiClient", () => {
   });
 
   describe("sync", () => {
-    it("calls /sync with snakified query params", async () => {
+    it("calls /sync with JSON body containing snakified params", async () => {
       const fetcher = makeFetcher();
       fetcher.fetch.mockResolvedValueOnce({
         statusCode: 200,
@@ -242,9 +258,14 @@ describe("TodoistApiClient", () => {
 
       const call = fetcher.fetch.mock.calls[0][0];
       expect(call.method).toBe("POST");
-      const { params } = parseUrl(call.url);
-      expect(params.get("sync_token")).toBe("old-token");
-      expect(params.get("resource_types")).not.toBeNull();
+      expect(call.headers["Content-Type"]).toBe("application/json");
+
+      const body = JSON.parse(call.body as string);
+      expect(body.sync_token).toBe("old-token");
+      expect(body.resource_types).toEqual(["projects", "labels", "sections"]);
+
+      const { pathname } = parseUrl(call.url);
+      expect(pathname).toBe("/api/v1/sync");
     });
   });
 

--- a/plugin/src/api/index.ts
+++ b/plugin/src/api/index.ts
@@ -47,11 +47,11 @@ export class TodoistApiClient {
   }
 
   public async sync(token: SyncToken): Promise<SyncResponse> {
-    const queryParams = snakify({
+    const body = snakify({
       syncToken: token,
-      resourceTypes: JSON.stringify(["projects", "labels", "sections"]),
+      resourceTypes: ["projects", "labels", "sections"],
     });
-    const response = await this.do("/sync", "POST", { queryParams });
+    const response = await this.do("/sync", "POST", { json: body });
     return parseApiResponse(syncResponseSchema, response.body);
   }
 
@@ -94,8 +94,10 @@ export class TodoistApiClient {
   ): Promise<WebResponse> {
     let queryString = "";
     if (opts.queryParams) {
-      const urlParams = new URLSearchParams(opts.queryParams);
-      queryString = `?${urlParams.toString()}`;
+      const parts = Object.entries(opts.queryParams).map(
+        ([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`,
+      );
+      queryString = `?${parts.join("&")}`;
     }
 
     const params: RequestParams = {


### PR DESCRIPTION
Two fixes for Todoist API v1 compatibility:

1. Sync endpoint: Send sync_token and resource_types as JSON body instead of query parameters, matching the official Todoist SDK. The resource_types is now sent as an actual array instead of a JSON-stringified string.

2. URL encoding: Use encodeURIComponent (percent-encoding with %20 for spaces) instead of URLSearchParams (form-encoding with + for spaces). This ensures filter queries like "(today | overdue) & assigned to: me" are encoded correctly for the Todoist API.

https://claude.ai/code/session_017C3TuW1q4MN5kEUwg2yLWV